### PR TITLE
Documentation

### DIFF
--- a/doc/aggregation.md
+++ b/doc/aggregation.md
@@ -1,0 +1,1 @@
+## Step 4 - Aggregation

--- a/doc/aggregation.md
+++ b/doc/aggregation.md
@@ -1,1 +1,2 @@
 ## Step 4 - Aggregation
+

--- a/doc/ajtai_commitment.md
+++ b/doc/ajtai_commitment.md
@@ -1,0 +1,51 @@
+## Step 2 - Ajtai Commitment
+In the first step of the protocol, the prover commits to the small-norm solution vectors  `s_1,...,s_r` by computing **Ajtai commitments**. 
+The idea behind a commitment is a cryptographic equivalent to keeping some knowledge sealed in an **'envelope'**, to be revealed later.
+Specifically, the prover computes the vector `t_i = A * s_i`, where `s_i` is a vector of `n` polynomials. 
+After multiplication, this results in vectors `t_i` of `k` polynomials. 
+However, sending the vectors `t_i` directly could be costly due to its potentially large size. 
+Therefore, the prover commits to the `t_i` using another Ajtai commitment, referred to as the **outer commitment**.
+
+### Decomposition for Efficiency
+
+The components of the vector `t_i` have coefficients that are arbitrary modulo `q`. 
+This may lead to inefficiencies when transferring large numbers. To optimize the transfer and reduce the size of the values being committed, 
+the coefficients need to be decomposed into smaller parts.
+
+The decomposition is done **element-wise**. Specifically, each polynomial in `t_i` is decomposed into `t_1 >= 2` parts with respect to a small base `b_1`, 
+such that:
+
+```
+t_i = t_i^(0) + t_i^(1) * b_1 + t_i^(2) * b_1^2 + ... + t_i^(t_1-1) * b_1^(t_1-1)
+```
+
+In this decomposition, centered representatives are used, which ensures that each element of the vector lies within the range `[-b_1 / 2, b_1 / 2]`.
+Once the decomposition is complete for each `t_i`, we concatenate all the decomposition coefficients `t_i^(k)` for each `i` and `k` to form a new vector `t`. 
+The second Ajtai commitment can then be written as:
+```
+u_1 = B * t
+```
+
+### Commitment to the Garbage Polynomial
+
+The protocol also includes a polynomial referred to as the garbage polynomial, which does not depend on any challenge during the interaction and is used in the amortization part. To simplify the proof of security, this polynomial is also committed to at the beginning of the protocol. To commit to the garbage polynomial, the prover can simply include it in the commitment to `t`. 
+
+The garbage polynomial commitment is handled similarly. Given that `g_ij = <s_i, s_j>` is the inner product of the solution vectors, 
+the prover constructs a symmetric matrix of polynomials. Each element of this matrix `g_ij` is decomposed based on some base `b_2` into `t_2 >= 2` parts and then each decomposition coefficient is concateated into `g` :
+
+```
+g_ij = g_ij^(0) + g_ij^(1) * b_2 + g_ij^(2) * b_2^2 + ... + g_ij^(t_2-1) * b_2^(t_2-1)
+```
+
+Finally, the full commitment to both the vector `t` and the garbage polynomial `g` is expressed as:
+```
+u_1 = B * t + C * g
+```
+
+### Norm Constraints & Common Reference String
+- A, B, and C are matrices that serve as common references between the verifier and the prover
+- `||t|| <= γ_1`
+- `||g|| <= γ_2`
+
+(More details on choosing the bases and γ will be added soon)
+

--- a/doc/ajtai_commitment.md
+++ b/doc/ajtai_commitment.md
@@ -1,43 +1,43 @@
 ## Step 2 - Ajtai Commitment
-In the first step of the protocol, the prover commits to the small-norm solution vectors  **s_1,...,s_r** by computing **Ajtai commitments**. 
+In the first step of the protocol, the prover commits to the small-norm solution vectors  $s_{1},...,s_{r}$ by computing **Ajtai commitments**. 
 The idea behind a commitment is a cryptographic equivalent to keeping some knowledge sealed in an **'envelope'**, to be revealed later.
-Specifically, the prover computes the vector **t_i = A * s_i**, where **s_i** is a vector of **n** polynomials. 
-After multiplication, this results in vectors **t_i** of **k** polynomials. 
-However, sending the vectors **t_i** directly could be costly due to its potentially large size. 
-Therefore, the prover commits to the **t_i** using another Ajtai commitment, referred to as the **outer commitment**.
+Specifically, the prover computes the vector $t_{i} = A * s_{i}$, where $s_{i}$ is a vector of $n$ polynomials. 
+After multiplication, this results in vectors $t_{i}$ of $k$ polynomials. 
+However, sending the vectors $t_{i}$ directly could be costly due to its potentially large size. 
+Therefore, the prover commits to the $t_{i}$ using another Ajtai commitment, referred to as the **outer commitment**.
 
 ### Decomposition for Efficiency
 
-The components of the vector **t_i** have coefficients that are arbitrary modulo **q**. 
+The components of the vector $t_(i)$ have coefficients that are arbitrary modulo $q$. 
 This may lead to inefficiencies when transferring large numbers. To optimize the transfer and reduce the size of the values being committed, 
 the coefficients need to be decomposed into smaller parts.
 
-The decomposition is done **element-wise**. Specifically, each polynomial in **t_i** is decomposed into **t_1 >= 2** parts with respect to a small base **b_1**, 
+The decomposition is done **element-wise**. Specifically, each polynomial in $t_{i}$ is decomposed into $t_{1} \geq 2$ parts with respect to a small base $b_{1}$, 
 such that:
 
-**t_i = t_i^(0) + t_i^(1) * b_1 + t_i^(2) * b_1^2 + ... + t_i^(t_1-1) * b_1^(t_1-1)**
+$$t_{i} = t_{i}\^{\(0\)} + t_{i}\^{1} * b_{1} + t_{i}\^{\(2\)} * b_{1}^{2} + ... + t_{i}^{\(t_{1}-1\)} * b_{1}^{t_{1}-1}$$
 
-In this decomposition, centered representatives are used, which ensures that each element of the vector lies within the range **[-b_1 / 2, b_1 / 2]**.
-Once the decomposition is complete for each **t_i**, we concatenate all the decomposition coefficients **t_i^(k)** for each **i** and **k** to form a new vector **t**. 
+In this decomposition, centered representatives are used, which ensures that each element of the vector lies within the range $\[\frac{-b_{1}}{2}, \frac{b_{1}}{2}\]$.
+Once the decomposition is complete for each $t_{i}$, we concatenate all the decomposition coefficients $t_{i}\^{k}$ for each $i$ and $k$ to form a new vector $t$. 
 The second Ajtai commitment can then be written as:
-**u_1 = B * t**
+$u_{1} = B * t$
 
 ### Commitment to the Garbage Polynomial
 
-The protocol also includes a polynomial referred to as the garbage polynomial, which does not depend on any challenge during the interaction and is used in the amortization part. To simplify the proof of security, this polynomial is also committed to at the beginning of the protocol. To commit to the garbage polynomial, the prover can simply include it in the commitment to **t**. 
+The protocol also includes a polynomial referred to as the garbage polynomial, which does not depend on any challenge during the interaction and is used in the amortization part. To simplify the proof of security, this polynomial is also committed to at the beginning of the protocol. To commit to the garbage polynomial, the prover can simply include it in the commitment to $t$. 
 
-The garbage polynomial commitment is handled similarly. Given that **g_ij = <s_i, s_j>** is the inner product of the solution vectors, 
-the prover constructs a symmetric matrix of polynomials. Each element of this matrix **g_ij** is decomposed based on some base **b_2** into **t_2 >= 2** parts and then each decomposition coefficient is concateated into **g** :
+The garbage polynomial commitment is handled similarly. Given that $g_ij = <s_{i}, s_{j}>$ is the inner product of the solution vectors, 
+the prover constructs a symmetric matrix of polynomials. Each element of this matrix $g_{ij}$ is decomposed based on some base $b_{2}$ into $t_{2} \geq 2$ parts and then each decomposition coefficient is concateated into $g$ :
 
-**g_ij = g_ij^(0) + g_ij^(1) * b_2 + g_ij^(2) * b_2^2 + ... + g_ij^(t_2-1) * b_2^(t_2-1)**
+$$g_{ij} = g_{ij}\^{\(0\)} + g_{ij}^{\(1\)} * b_{2} + g_{ij}\^{\(2\)} * b_{2}\^{2} + ... + g_{ij}\^{\(t_{2}-1\)} * b_{2}\^{t_2-1}$$
 
-Finally, the full commitment to both the vector **t** and the garbage polynomial **g** is expressed as:
-**u_1 = B * t + C * g**
+Finally, the full commitment to both the vector $t$ and the garbage polynomial $g$ is expressed as:
+$$u_{1} = B * t + C * g$$
 
 ### Norm Constraints & Common Reference String
-- A, B, and C are matrices that serve as common references between the verifier and the prover
-- **||t|| <= γ_1**
-- **||g|| <= γ_2**
+- $A$, $B$, and $C$ are matrices that serve as common references between the verifier and the prover
+- ||$t$|| $\leq γ_{1}$
+- ||$g$|| $\leq γ_{2}$
 
-(More details on choosing the bases and γ will be added soon)
+(More details on choosing the bases and $γ$ will be added soon)
 

--- a/doc/ajtai_commitment.md
+++ b/doc/ajtai_commitment.md
@@ -1,51 +1,43 @@
 ## Step 2 - Ajtai Commitment
-In the first step of the protocol, the prover commits to the small-norm solution vectors  `s_1,...,s_r` by computing **Ajtai commitments**. 
+In the first step of the protocol, the prover commits to the small-norm solution vectors  **s_1,...,s_r** by computing **Ajtai commitments**. 
 The idea behind a commitment is a cryptographic equivalent to keeping some knowledge sealed in an **'envelope'**, to be revealed later.
-Specifically, the prover computes the vector `t_i = A * s_i`, where `s_i` is a vector of `n` polynomials. 
-After multiplication, this results in vectors `t_i` of `k` polynomials. 
-However, sending the vectors `t_i` directly could be costly due to its potentially large size. 
-Therefore, the prover commits to the `t_i` using another Ajtai commitment, referred to as the **outer commitment**.
+Specifically, the prover computes the vector **t_i = A * s_i**, where **s_i** is a vector of **n** polynomials. 
+After multiplication, this results in vectors **t_i** of **k** polynomials. 
+However, sending the vectors **t_i** directly could be costly due to its potentially large size. 
+Therefore, the prover commits to the **t_i** using another Ajtai commitment, referred to as the **outer commitment**.
 
 ### Decomposition for Efficiency
 
-The components of the vector `t_i` have coefficients that are arbitrary modulo `q`. 
+The components of the vector **t_i** have coefficients that are arbitrary modulo **q**. 
 This may lead to inefficiencies when transferring large numbers. To optimize the transfer and reduce the size of the values being committed, 
 the coefficients need to be decomposed into smaller parts.
 
-The decomposition is done **element-wise**. Specifically, each polynomial in `t_i` is decomposed into `t_1 >= 2` parts with respect to a small base `b_1`, 
+The decomposition is done **element-wise**. Specifically, each polynomial in **t_i** is decomposed into **t_1 >= 2** parts with respect to a small base **b_1**, 
 such that:
 
-```
-t_i = t_i^(0) + t_i^(1) * b_1 + t_i^(2) * b_1^2 + ... + t_i^(t_1-1) * b_1^(t_1-1)
-```
+**t_i = t_i^(0) + t_i^(1) * b_1 + t_i^(2) * b_1^2 + ... + t_i^(t_1-1) * b_1^(t_1-1)**
 
-In this decomposition, centered representatives are used, which ensures that each element of the vector lies within the range `[-b_1 / 2, b_1 / 2]`.
-Once the decomposition is complete for each `t_i`, we concatenate all the decomposition coefficients `t_i^(k)` for each `i` and `k` to form a new vector `t`. 
+In this decomposition, centered representatives are used, which ensures that each element of the vector lies within the range **[-b_1 / 2, b_1 / 2]**.
+Once the decomposition is complete for each **t_i**, we concatenate all the decomposition coefficients **t_i^(k)** for each **i** and **k** to form a new vector **t**. 
 The second Ajtai commitment can then be written as:
-```
-u_1 = B * t
-```
+**u_1 = B * t**
 
 ### Commitment to the Garbage Polynomial
 
-The protocol also includes a polynomial referred to as the garbage polynomial, which does not depend on any challenge during the interaction and is used in the amortization part. To simplify the proof of security, this polynomial is also committed to at the beginning of the protocol. To commit to the garbage polynomial, the prover can simply include it in the commitment to `t`. 
+The protocol also includes a polynomial referred to as the garbage polynomial, which does not depend on any challenge during the interaction and is used in the amortization part. To simplify the proof of security, this polynomial is also committed to at the beginning of the protocol. To commit to the garbage polynomial, the prover can simply include it in the commitment to **t**. 
 
-The garbage polynomial commitment is handled similarly. Given that `g_ij = <s_i, s_j>` is the inner product of the solution vectors, 
-the prover constructs a symmetric matrix of polynomials. Each element of this matrix `g_ij` is decomposed based on some base `b_2` into `t_2 >= 2` parts and then each decomposition coefficient is concateated into `g` :
+The garbage polynomial commitment is handled similarly. Given that **g_ij = <s_i, s_j>** is the inner product of the solution vectors, 
+the prover constructs a symmetric matrix of polynomials. Each element of this matrix **g_ij** is decomposed based on some base **b_2** into **t_2 >= 2** parts and then each decomposition coefficient is concateated into **g** :
 
-```
-g_ij = g_ij^(0) + g_ij^(1) * b_2 + g_ij^(2) * b_2^2 + ... + g_ij^(t_2-1) * b_2^(t_2-1)
-```
+**g_ij = g_ij^(0) + g_ij^(1) * b_2 + g_ij^(2) * b_2^2 + ... + g_ij^(t_2-1) * b_2^(t_2-1)**
 
-Finally, the full commitment to both the vector `t` and the garbage polynomial `g` is expressed as:
-```
-u_1 = B * t + C * g
-```
+Finally, the full commitment to both the vector **t** and the garbage polynomial **g** is expressed as:
+**u_1 = B * t + C * g**
 
 ### Norm Constraints & Common Reference String
 - A, B, and C are matrices that serve as common references between the verifier and the prover
-- `||t|| <= γ_1`
-- `||g|| <= γ_2`
+- **||t|| <= γ_1**
+- **||g|| <= γ_2**
 
 (More details on choosing the bases and γ will be added soon)
 

--- a/doc/amortization.md
+++ b/doc/amortization.md
@@ -1,0 +1,1 @@
+## Step 5 - Amortization

--- a/doc/arithmetic_circuit_translation.md
+++ b/doc/arithmetic_circuit_translation.md
@@ -1,0 +1,1 @@
+## Step 1 - Arithmetic Circuit Translation

--- a/doc/mainpage-doc.md
+++ b/doc/mainpage-doc.md
@@ -2,7 +2,7 @@
 
 This is the code implementation of LaBRADOR, a lattice-based proof system for R1CS that achieves proof sizes of logarithmic order.  
 These notes serve as a friendly introduction to the protocol and a prototype for the documentation.  
-The main idea is to define a protocol between a prover **P** and a verifier **V**, where, given an initial arithmetic circuit, they can perform an interaction **<P, V>**. This interaction allows the prover to demonstrate knowledge of solutions to the circuit, and the verifier will output a binary result indicating whether the proof was accepted.  
+The main idea is to define a protocol between a prover $P$ and a verifier $V$, where, given an initial arithmetic circuit, they can perform an interaction $<P, V>$. This interaction allows the prover to demonstrate knowledge of solutions to the circuit, and the verifier will output a binary result indicating whether the proof was accepted.  
 Protocols of this type already exist, but LaBRADOR has the added advantage of achieving sublinear proof sizes while relying on (provably) post-quantum secure cryptographic lattice problems.
 
 *(This documentation is still under construction)*

--- a/doc/mainpage-doc.md
+++ b/doc/mainpage-doc.md
@@ -16,13 +16,5 @@ The protocol, from the circuit to the final proof, can be described through the 
 4. Make the proof more compact by aggregating multiple constraints (Aggregation).  
 5. Only prove linear combinations of the commitments (Amortization).  
 
-## Step 1 - Arithmetic Circuit Translation
 
-## Step 2 - Ajtai Commitment
-
-## Step 3 - Projections (Johnson-Lindenstrauss)
-
-## Step 4 - Aggregation
-
-## Step 5 - Amortization
 

--- a/doc/mainpage-doc.md
+++ b/doc/mainpage-doc.md
@@ -2,7 +2,7 @@
 
 This is the code implementation of LaBRADOR, a lattice-based proof system for R1CS that achieves proof sizes of logarithmic order.  
 These notes serve as a friendly introduction to the protocol and a prototype for the documentation.  
-The main idea is to define a protocol between a prover **P** and a verifier **V**, where, given an initial arithmetic circuit, they can perform an interaction `<P, V>`. This interaction allows the prover to demonstrate knowledge of solutions to the circuit, and the verifier will output a binary result indicating whether the proof was accepted.  
+The main idea is to define a protocol between a prover **P** and a verifier **V**, where, given an initial arithmetic circuit, they can perform an interaction **<P, V>**. This interaction allows the prover to demonstrate knowledge of solutions to the circuit, and the verifier will output a binary result indicating whether the proof was accepted.  
 Protocols of this type already exist, but LaBRADOR has the added advantage of achieving sublinear proof sizes while relying on (provably) post-quantum secure cryptographic lattice problems.
 
 *(This documentation is still under construction)*

--- a/doc/projections.md
+++ b/doc/projections.md
@@ -1,0 +1,1 @@
+## Step 3 - Projections (Johnson-Lindenstrauss)

--- a/doc/projections.md
+++ b/doc/projections.md
@@ -1,1 +1,3 @@
 ## Step 3 - Projections (Johnson-Lindenstrauss)
+The main idea behind the Modular Johnson-Lindenstrauss Lemma is that if you want to prove that a long vector has a small norm, instead of having to send the entire vector to verify this condition, the verifier can send random linear projections as challenges to the prover and then the prover just needs to return the aplied proyection to the vector. The lemma guarantees that the projections almost preserve the L2 norm, so by performing a sufficient number of challenges, one can gain information about the actual norm size of the original vector.
+

--- a/katex-header.html
+++ b/katex-header.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.css" integrity="sha384-9eLZqc9ds8eNjO3TmqPeYcDj8n+Qfa4nuSiGYa6DjLNcv9BtN69ZIulL9+8CqC9Y" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.js"                  integrity="sha384-K3vbOmF2BtaVai+Qk37uypf7VrgBubhQreNQe9aGsz9lB63dIFiQVlJbr92dw2Lx" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/contrib/auto-render.min.js"    integrity="sha384-kmZOZB5ObwgQnS/DuDg6TScgOiWWBiVt0plIRkZCmE6rDZGrEOQeHM5PcHi+nyqe" crossorigin="anonymous"></script>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        renderMathInElement(document.body, {
+            delimiters: [
+                {left: "$$", right: "$$", display: true},
+                {left: "\\(", right: "\\)", display: false},
+                {left: "$", right: "$", display: false},
+                {left: "\\[", right: "\\]", display: true}
+            ]
+        });
+    });
+</script>

--- a/labrador/src/lib.rs
+++ b/labrador/src/lib.rs
@@ -1,4 +1,22 @@
+// Documentation
+
+// Main Introduction
 #![doc = include_str!("../../doc/mainpage-doc.md")]
+
+// Arithmetic Circuit Translation
+#![doc = include_str!("../../doc/arithmetic_circuit_translation.md")]
+
+// Ajtai Commitment
+#![doc = include_str!("../../doc/ajtai_commitment.md")]
+
+// Projections
+#![doc = include_str!("../../doc/projections.md")]
+
+// Aggregation
+#![doc = include_str!("../../doc/aggregation.md")]
+
+// Amortization
+#![doc = include_str!("../../doc/amortization.md")]
 
 /// Prints a "Hello, world!" message
 pub fn say_hello() {


### PR DESCRIPTION
**Changes:**

-  Documentation has been divided into several documents (a markdown file per step)
- Latex is now allowed for local rendering. Following the guide by https://docs.rs/rustdoc-katex-demo/0.1.5/rustdoc_katex_demo/
- Added text on Ajtai Commitment Scheme and Johnson-Lindenstrauss lema
- Formulas are now on Latex
- A ,html file was added in order to allow Latex math formulas 